### PR TITLE
Enabled tab list items to contain HTML content.

### DIFF
--- a/js/responsiveTabs.js
+++ b/js/responsiveTabs.js
@@ -68,11 +68,11 @@ var RESPONSIVEUI = {};
 					//associate tab list item with tab panel
 					var $tabListItem = $('<li/>', { 
 						'class': 'responsive-tabs__list__item',
+						html: $tabHeading.html(),
 						id: 'tablist' + tablistcount + '-tab' + tabcount,
 						'aria-controls': 'tablist' + tablistcount +'-panel' + tabcount,
 						'role': 'tab',
 						tabindex: 0,
-						text: $tabHeading.text(),
 						keydown: function (objEvent) {
 							if (objEvent.keyCode === 13) { // if user presses 'enter'
 								$tabListItem.click();


### PR DESCRIPTION
In a recent project, I found that we needed HTML elements to be placed inside the content of a tab list item, so I made this change to enable that.  I think it's a valuable change that will help others without breaking anyone's code.
