### PR TITLE
CSS to get Tabs Stacked Vertically Beside the Content

### DIFF
--- a/css/Tabs-Stacked-Vertically.css
+++ b/css/Tabs-Stacked-Vertically.css
@@ -37,6 +37,14 @@
     margin-left: -1px;
     padding-left: 25px;
 }
+@media (max-width: 767px) {
+	.vertical-tabs .responsive-tabs__panel {
+		float: none;
+		border: none;
+		min-height: none;
+		margin-left: 0;
+	}
+}
 @media only screen and (min-width: 768px) and (max-width: 979px) {
     .vertical-tabs .responsive-tabs__list {
 	width: 18%;


### PR DESCRIPTION
It works fine with the standard version and with the modification proposed by ajmueller (to enable tab list items to contain HTML content).

Perhaps some adjustments of the widths (list and panel) will be needed depending on the breakpoints you have.
